### PR TITLE
[Model] Add Qwen3 and allow switching between thinking and non-thinking mode

### DIFF
--- a/app/client/api.ts
+++ b/app/client/api.ts
@@ -33,6 +33,7 @@ export interface LLMConfig {
   stream?: boolean;
   presence_penalty?: number;
   frequency_penalty?: number;
+  enable_thinking?: boolean;
 }
 
 export interface ChatOptions {

--- a/app/client/webllm.ts
+++ b/app/client/webllm.ts
@@ -84,6 +84,18 @@ export class WebLLMApi implements LLMApi {
   async chat(options: ChatOptions): Promise<void> {
     if (!this.initialized || this.isDifferentConfig(options.config)) {
       this.llmConfig = { ...(this.llmConfig || {}), ...options.config };
+      // Check if this is a Qwen3 model with thinking mode enabled
+      const isQwen3Model = this.llmConfig?.model?.startsWith("Qwen3");
+      const isThinkingEnabled = this.llmConfig?.enable_thinking === true;
+
+      // Apply special config for Qwen3 models with thinking mode enabled
+      if (isQwen3Model && isThinkingEnabled && this.llmConfig) {
+        this.llmConfig = {
+          ...this.llmConfig,
+          temperature: 0.6,
+          top_p: 0.95,
+        };
+      }
       try {
         await this.initModel(options.onUpdate);
       } catch (err: any) {
@@ -184,10 +196,37 @@ export class WebLLMApi implements LLMApi {
       usage?: CompletionUsage,
     ) => void,
   ) {
+    // For Qwen3 models, we need to filter out the <think>...</think> content
+    // Do not do it inplace, create a new messages array
+    let newMessages: RequestMessage[] | undefined;
+    const isQwen3Model = this.llmConfig?.model?.startsWith("Qwen3");
+    if (isQwen3Model) {
+      newMessages = messages.map((message) => {
+        const newMessage = { ...message };
+        if (
+          message.role === "assistant" &&
+          typeof message.content === "string"
+        ) {
+          newMessage.content = message.content.replace(
+            /^<think>[\s\S]*?<\/think>\n?\n?/,
+            "",
+          );
+        }
+        return newMessage;
+      });
+    }
+
+    // Prepare extra_body with enable_thinking option for Qwen3 models
+    const extraBody: Record<string, any> = {};
+    if (isQwen3Model) {
+      extraBody.enable_thinking = this.llmConfig?.enable_thinking ?? false;
+    }
+
     const completion = await this.webllm.engine.chatCompletion({
       stream: stream,
-      messages: messages as ChatCompletionMessageParam[],
+      messages: (newMessages || messages) as ChatCompletionMessageParam[],
       ...(stream ? { stream_options: { include_usage: true } } : {}),
+      ...(Object.keys(extraBody).length > 0 ? { extra_body: extraBody } : {}),
     });
 
     if (stream) {

--- a/app/components/settings.tsx
+++ b/app/components/settings.tsx
@@ -538,6 +538,20 @@ export function Settings() {
             </Select>
           </ListItem>
           <ListItem
+            title={Locale.Settings.EnableThinking.Title}
+            subTitle={Locale.Settings.EnableThinking.SubTitle}
+          >
+            <input
+              type="checkbox"
+              checked={config.enableThinking}
+              onChange={(e) =>
+                updateConfig(
+                  (config) => (config.enableThinking = e.currentTarget.checked),
+                )
+              }
+            ></input>
+          </ListItem>
+          <ListItem
             title={Locale.Settings.LogLevel.Title}
             subTitle={Locale.Settings.LogLevel.SubTitle}
           >

--- a/app/constant.ts
+++ b/app/constant.ts
@@ -79,6 +79,20 @@ export enum ModelFamily {
   DEEPSEEK = "DeepSeek",
 }
 
+const qwen3_common_configs = {
+  display_name: "Qwen",
+  provider: "Alibaba",
+  family: ModelFamily.QWEN,
+  // Recommended config is for non-thinking mode
+  // For thinking mode, see webllm.ts where temperature=0.6 and top_p=0.95 are applied
+  recommended_config: {
+    temperature: 0.7,
+    presence_penalty: 0,
+    frequency_penalty: 0,
+    top_p: 0.8,
+  },
+};
+
 const DEFAULT_MODEL_BASES: ModelRecord[] = [
   // Phi-3.5 Vision
   {
@@ -410,6 +424,7 @@ const DEFAULT_MODEL_BASES: ModelRecord[] = [
       top_p: 1,
     },
   },
+  // Mistral
   {
     name: "Mistral-7B-Instruct-v0.3-q4f16_1-MLC",
     display_name: "Mistral",
@@ -464,6 +479,7 @@ const DEFAULT_MODEL_BASES: ModelRecord[] = [
       top_p: 0.95,
     },
   },
+  // WizardMath
   {
     name: "WizardMath-7B-V1.1-q4f16_1-MLC",
     display_name: "WizardMath",
@@ -571,6 +587,48 @@ const DEFAULT_MODEL_BASES: ModelRecord[] = [
       top_p: 1,
     },
   },
+  // Qwen3
+  {
+    name: "Qwen3-0.6B-q4f16_1-MLC",
+    ...qwen3_common_configs,
+  },
+  {
+    name: "Qwen3-0.6B-q4f32_1-MLC",
+    ...qwen3_common_configs,
+  },
+  {
+    name: "Qwen3-0.6B-q0f16-MLC",
+    ...qwen3_common_configs,
+  },
+  {
+    name: "Qwen3-0.6B-q0f32-MLC",
+    ...qwen3_common_configs,
+  },
+  {
+    name: "Qwen3-1.7B-q4f16_1-MLC",
+    ...qwen3_common_configs,
+  },
+  {
+    name: "Qwen3-1.7B-q4f32_1-MLC",
+    ...qwen3_common_configs,
+  },
+  {
+    name: "Qwen3-4B-q4f16_1-MLC",
+    ...qwen3_common_configs,
+  },
+  {
+    name: "Qwen3-4B-q4f32_1-MLC",
+    ...qwen3_common_configs,
+  },
+  {
+    name: "Qwen3-8B-q4f16_1-MLC",
+    ...qwen3_common_configs,
+  },
+  {
+    name: "Qwen3-8B-q4f32_1-MLC",
+    ...qwen3_common_configs,
+  },
+  // Qwen2.5
   {
     name: "Qwen2.5-0.5B-Instruct-q4f16_1-MLC",
     display_name: "Qwen",
@@ -585,18 +643,6 @@ const DEFAULT_MODEL_BASES: ModelRecord[] = [
   },
   {
     name: "Qwen2.5-0.5B-Instruct-q4f32_1-MLC",
-    display_name: "Qwen",
-    provider: "Alibaba",
-    family: ModelFamily.QWEN,
-    recommended_config: {
-      temperature: 0.7,
-      presence_penalty: 0,
-      frequency_penalty: 0,
-      top_p: 0.8,
-    },
-  },
-  {
-    name: "Qwen2.5-0.5B-Instruct-q4f16_1-MLC",
     display_name: "Qwen",
     provider: "Alibaba",
     family: ModelFamily.QWEN,
@@ -873,6 +919,7 @@ const DEFAULT_MODEL_BASES: ModelRecord[] = [
       top_p: 0.8,
     },
   },
+  // Gemma 2
   {
     name: "gemma-2-2b-it-q4f16_1-MLC",
     display_name: "Gemma",
@@ -969,6 +1016,7 @@ const DEFAULT_MODEL_BASES: ModelRecord[] = [
       top_p: 0.9,
     },
   },
+  // StableLM
   {
     name: "stablelm-2-zephyr-1_6b-q4f16_1-MLC",
     display_name: "StableLM",
@@ -1017,6 +1065,7 @@ const DEFAULT_MODEL_BASES: ModelRecord[] = [
       top_p: 0.95,
     },
   },
+  // RedPajama
   {
     name: "RedPajama-INCITE-Chat-3B-v1-q4f16_1-MLC",
     display_name: "RedPajama",
@@ -1057,6 +1106,7 @@ const DEFAULT_MODEL_BASES: ModelRecord[] = [
       top_p: 0.95,
     },
   },
+  // TinyLlama
   {
     name: "TinyLlama-1.1B-Chat-v1.0-q4f16_1-MLC",
     display_name: "TinyLlama",
@@ -1105,6 +1155,7 @@ const DEFAULT_MODEL_BASES: ModelRecord[] = [
       top_p: 1,
     },
   },
+  // Older models
   {
     name: "Llama-3.1-70B-Instruct-q3f16_1-MLC",
     display_name: "Llama",

--- a/app/locales/en.ts
+++ b/app/locales/en.ts
@@ -264,6 +264,10 @@ const en = {
       Title: "Logging Level",
       SubTitle: "Adjust how much detail should be printed to console",
     },
+    EnableThinking: {
+      Title: "Enable Thinking for Qwen3",
+      SubTitle: "Allow Qwen3 models to show thinking process in responses",
+    },
   },
   Store: {
     DefaultTopic: "New Conversation",

--- a/app/store/chat.ts
+++ b/app/store/chat.ts
@@ -347,6 +347,7 @@ export const useChatStore = createPersistStore(
             ...modelConfig,
             cache: useAppConfig.getState().cacheType,
             stream: true,
+            enable_thinking: useAppConfig.getState().enableThinking,
           },
           onUpdate(message) {
             botMessage.streaming = true;
@@ -532,6 +533,7 @@ export const useChatStore = createPersistStore(
               model: modelConfig.model,
               cache: useAppConfig.getState().cacheType,
               stream: false,
+              enable_thinking: false, // never think for topic
             },
             onFinish(message) {
               get().updateCurrentSession(
@@ -615,6 +617,7 @@ export const useChatStore = createPersistStore(
               stream: true,
               model: modelConfig.model,
               cache: useAppConfig.getState().cacheType,
+              enable_thinking: false, // never think for summarization
             },
             onUpdate(message) {
               session.memoryPrompt = message;

--- a/app/store/config.ts
+++ b/app/store/config.ts
@@ -75,6 +75,7 @@ export type ConfigType = {
 
   cacheType: CacheType;
   logLevel: LogLevel;
+  enableThinking: boolean;
   modelConfig: ModelConfig;
 };
 
@@ -124,6 +125,7 @@ export const DEFAULT_CONFIG: ConfigType = {
   models: DEFAULT_MODELS,
   cacheType: CacheType.Cache,
   logLevel: "INFO",
+  enableThinking: false,
 
   modelConfig: DEFAULT_MODEL_CONFIG,
 };

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "@fortaine/fetch-event-source": "^3.0.6",
     "@hello-pangea/dnd": "^16.5.0",
-    "@mlc-ai/web-llm": "^0.2.78",
+    "@mlc-ai/web-llm": "^0.2.79",
     "@serwist/next": "^9.0.2",
     "@svgr/webpack": "^6.5.1",
     "emoji-picker-react": "^4.9.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1180,10 +1180,10 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
-"@mlc-ai/web-llm@^0.2.78":
-  version "0.2.78"
-  resolved "https://registry.yarnpkg.com/@mlc-ai/web-llm/-/web-llm-0.2.78.tgz#f9ce70319b86bb8c0dd4b1a0476152e4fd3e82be"
-  integrity sha512-ptqDNzHnfDyNZj7vjp9IaY5U/QDweXMe5wNzErOmRT1gqj8AaMvcqbj7HroPDzhXJGM7BZpDjANV5MhXhKOosA==
+"@mlc-ai/web-llm@^0.2.79":
+  version "0.2.79"
+  resolved "https://registry.yarnpkg.com/@mlc-ai/web-llm/-/web-llm-0.2.79.tgz#a0dcfc54bf5d843090be67fd9b168e4de087bc93"
+  integrity sha512-Hy1ZHQ0o2bZGZoVnGK48+fts/ZSKwLe96xjvqL/6C59Mem9HoHTcFE07NC2E23mRmhd01tL655N6CPeYmwWgwQ==
   dependencies:
     loglevel "^1.9.1"
 


### PR DESCRIPTION
This PR adds Qwen3 models from WebLLM 0.2.79.

We also add a config `enable_thinking` that can be toggled in the settings page to decide whether the Qwen3 model should reason or not. By default, it is turned off. Turning it on will cause it to reason and will also change its `temperature` and `top_p`, following https://huggingface.co/Qwen/Qwen3-0.6B#best-practices

In addition, when we want to summarize/create a topic, we should never reason, as it would take way too long.

In addition, for multi-round chat, we remove the `<think>thinking tokens here</think>\n\n` from the history assistant's message.

TODO: In my offline testing, the toggling of reasoning does not seem very robust.