### PR TITLE
Try to prettify google search result

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,9 +6,22 @@ import { getClientConfig } from "./config/client";
 import { type Metadata } from "next";
 
 export const metadata: Metadata = {
+  metadataBase: new URL("https://chat.webllm.ai"),
   title: "WebLLM Chat",
   description:
     "Chat with AI large language models running natively in your browser. Enjoy private, server-free, seamless AI conversations.",
+  keywords: [
+    "WebLLM",
+    "AI chat",
+    "machine learning",
+    "browser AI",
+    "language model",
+    "no server",
+  ],
+  authors: [{ name: "WebLLM Team" }],
+  publisher: "WebLLM",
+  creator: "WebLLM",
+  robots: "index, follow",
   viewport: {
     width: "device-width",
     initialScale: 1,
@@ -21,6 +34,32 @@ export const metadata: Metadata = {
   appleWebApp: {
     title: "WebLLM Chat",
     statusBarStyle: "default",
+  },
+  openGraph: {
+    type: "website",
+    url: "https://chat.webllm.ai",
+    title: "WebLLM Chat",
+    description:
+      "Chat with AI large language models running natively in your browser",
+    siteName: "WebLLM Chat",
+    images: [
+      {
+        url: "https://chat.webllm.ai/mlc-logo.png",
+        width: 360,
+        height: 360,
+        alt: "WebLLM Chat - Browser-based AI conversation",
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "WebLLM Chat",
+    description:
+      "Chat with AI large language models running natively in your browser",
+    images: ["https://chat.webllm.ai/mlc-logo.png"],
+  },
+  alternates: {
+    canonical: "https://chat.webllm.ai",
   },
 };
 
@@ -78,6 +117,30 @@ export default function RootLayout({
         <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#062578" />
         <meta name="msapplication-TileColor" content="#2b5797" />
         <meta name="theme-color" content="#ffffff" />
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{
+            __html: JSON.stringify({
+              "@context": "https://schema.org",
+              "@type": "WebApplication",
+              name: "WebLLM Chat",
+              url: "https://chat.webllm.ai",
+              description:
+                "Chat with AI large language models running natively in your browser. Enjoy private, server-free, seamless AI conversations.",
+              applicationCategory: "Artificial Intelligence",
+              offers: {
+                "@type": "Offer",
+                price: "0",
+                priceCurrency: "USD",
+              },
+              operatingSystem: "Web Browser",
+              creator: {
+                "@type": "Organization",
+                name: "WebLLM",
+              },
+            }),
+          }}
+        />
       </head>
       <body>{children}</body>
     </html>

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,4 +1,3 @@
 User-agent: *
-Disallow: /
-User-agent: vitals.vercel-insights.com
 Allow: /
+Sitemap: https://chat.webllm.ai/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://chat.webllm.ai/</loc>
+    <lastmod>2025-05-05</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>1.0</priority>
+  </url>
+</urlset> 


### PR DESCRIPTION
Currently searching "WebLLM Chat" on Google would display the following weird result:
<img src="https://github.com/user-attachments/assets/42b05db9-5431-4af7-b699-9fcd40c05879" width="450">


This PR attempts to change that. All code is generated by Cursor and I have not checked whether it works.