### PR TITLE
Fix for "[husky] install command is deprecated"

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "export": "cross-env BUILD_MODE=export next build",
     "export:dev": "cross-env BUILD_MODE=export next dev",
     "prompts": "node ./scripts/fetch-prompts.mjs",
-    "prepare": "husky install",
+    "prepare": "husky",
     "proxy-dev": "sh ./scripts/init-proxy.sh && proxychains -f ./scripts/proxychains.conf yarn dev"
   },
   "dependencies": {


### PR DESCRIPTION
This PR fixes an issue that I faced installed the repo. Steps to reproduce
```
git clone https://github.com/mlc-ai/web-llm-chat
cd web-llm-chat
yarn
```

This will install yarn, and then go the the `prepare` prehook which runs `husky install` and throws an error `"install command is deprecated"`.
This can also be confirmed by running `npx husky install`

Setup:
- Ubuntu 22.04
- Nodejs 22.3.0
- npm 10.8.1