### PR TITLE
Fixed a typo in README.md (ganranteed -> guaranteed)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 ## Key Features
 
 - **Browser-Native AI**: Experience cutting-edge language models running natively within your web browser with WebGPU acceleration, eliminating the need for server-side processing or cloud dependencies.
-- **Ganranteed Privacy**: With the AI model running locally on your hardware and all data processing happening within your browser, your data and conversations never leave your computer, ensuring your privacy.
+- **Guaranteed Privacy**: With the AI model running locally on your hardware and all data processing happening within your browser, your data and conversations never leave your computer, ensuring your privacy.
 - **Offline Accessibility**: Run entirely offline after the initial setup and download, allowing you to engage with AI-powered conversations without an active internet connection.
 - **Vision Model Support**: Chat with AI by uploading and sending images, making it easy to get insights and answers based on visual content.
 - **User-Friendly Interface**: Enjoy the intuitive and feature-rich user interface, complete with markdown support, dark mode, and a responsive design optimized for various screen sizes.


### PR DESCRIPTION
Fixed a typo in `README.md`:
1. Before: `Ganranteed`
2. After: `Guaranteed`