### PR TITLE
Fix Worker initialization error

### DIFF
--- a/app/components/home.tsx
+++ b/app/components/home.tsx
@@ -239,9 +239,9 @@ const useWebLLM = () => {
     }
   }, []);
 
-  if (webllm?.webllm.type === "serviceWorker") {
+  if (webllm?.webllm?.type === "serviceWorker") {
     setInterval(() => {
-      if (webllm) {
+      if (webllm?.webllm) {
         // 10s per heartbeat, dead after 30 seconds of inactivity
         setWebllmAlive(
           !!webllm.webllm.engine &&
@@ -314,7 +314,7 @@ const useLogLevel = (webllm?: WebLLMApi) => {
   useEffect(() => {
     log.setLevel(config.logLevel);
     if (webllm?.webllm?.engine) {
-      webllm.webllm.engine.setLogLevel(config.logLevel);
+      webllm?.webllm?.engine.setLogLevel(config.logLevel);
     }
   }, [config.logLevel, webllm?.webllm?.engine]);
 };


### PR DESCRIPTION
Fixes: #68 

Delays worker initialization until after SSR to avoid startup error, by moving init into an `initEngine` function that checks `typeof window === "undefined"` before creating the worker.