### PR TITLE
docs: add CI/CD Vercel secret requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,40 @@ If your proxy needs password, use:
 -e PROXY_URL="http://127.0.0.1:7890 user pass"
 ```
 
+## CI/CD Prerequisites
+
+Vercel deployment workflows require GitHub Actions repository secrets. Configure these before using CI/CD deployment automation.
+
+### Required GitHub Actions Secrets
+
+| Secret | Used by | Purpose |
+| --- | --- | --- |
+| `VERCEL_TOKEN` | `.github/workflows/vercel_deploy.yaml`, `.github/workflows/deploy_preview.yml`, `.github/workflows/remove_deploy_preview.yml` | Authenticates Vercel CLI and cleanup API calls. |
+| `VERCEL_ORG_ID` | `.github/workflows/vercel_deploy.yaml`, `.github/workflows/deploy_preview.yml`, `.github/workflows/remove_deploy_preview.yml` | Selects Vercel organization/team context. |
+| `VERCEL_PROJECT_ID` | `.github/workflows/vercel_deploy.yaml`, `.github/workflows/deploy_preview.yml`, `.github/workflows/remove_deploy_preview.yml` | Selects target Vercel project. |
+
+Forks and self-hosted variants must provide their own values for these secrets.
+
+### Setup
+
+1. Open repository **Settings > Secrets and variables > Actions**.
+2. Add the three required repository secrets listed above.
+3. Re-run any failed workflow (or push a new commit) to verify setup.
+
+### Failure Symptoms
+
+- Missing `VERCEL_TOKEN`: `vercel pull`, `vercel build`, or `vercel deploy` fails with authentication errors.
+- Missing `VERCEL_ORG_ID` / `VERCEL_PROJECT_ID`: Vercel project/org resolution fails.
+- Missing secrets in preview cleanup: `.github/workflows/remove_deploy_preview.yml` cannot query/delete preview deployments.
+
+### Quick Verification
+
+1. Push a non-main branch commit and confirm `.github/workflows/deploy_preview.yml` completes.
+2. Push or merge to main and confirm `.github/workflows/vercel_deploy.yaml` completes.
+3. Close a PR from a preview branch and confirm `.github/workflows/remove_deploy_preview.yml` runs cleanup.
+
+For detailed operator guidance, see [docs/ci-cd-secrets.md](docs/ci-cd-secrets.md).
+
 ## Community and Contributions
 
 WebLLM Chat thrives on community involvement. We are committed to fostering an inclusive and innovative community where developers and AI enthusiasts can collaborate, contribute, and push the boundaries of what's possible in AI technology. Join us on Discord to connect with fellow developers and contribute to the project.

--- a/docs/ci-cd-secrets.md
+++ b/docs/ci-cd-secrets.md
@@ -1,0 +1,58 @@
+# CI/CD Secrets for Vercel Workflows
+
+This document explains the GitHub Actions secrets required by Vercel-related workflows in this repository.
+
+## Required Secrets
+
+| Secret | Required | Purpose |
+| --- | --- | --- |
+| `VERCEL_TOKEN` | Yes | Authenticates Vercel CLI commands and Vercel API calls used in deployment and preview cleanup. |
+| `VERCEL_ORG_ID` | Yes | Identifies the Vercel team/org context used by workflows. |
+| `VERCEL_PROJECT_ID` | Yes | Identifies the Vercel project to deploy and manage. |
+
+## Workflow Dependency Matrix
+
+| Workflow | Trigger | Secrets Used |
+| --- | --- | --- |
+| [.github/workflows/vercel_deploy.yaml](../.github/workflows/vercel_deploy.yaml) | Push to `main` | `VERCEL_TOKEN`, `VERCEL_ORG_ID`, `VERCEL_PROJECT_ID` |
+| [.github/workflows/deploy_preview.yml](../.github/workflows/deploy_preview.yml) | Push to non-`main` branches | `VERCEL_TOKEN`, `VERCEL_ORG_ID`, `VERCEL_PROJECT_ID` |
+| [.github/workflows/remove_deploy_preview.yml](../.github/workflows/remove_deploy_preview.yml) | `pull_request_target` on close | `VERCEL_TOKEN`, `VERCEL_ORG_ID`, `VERCEL_PROJECT_ID` |
+
+## How to Configure Secrets in GitHub
+
+1. Open the repository on GitHub.
+2. Navigate to **Settings > Secrets and variables > Actions**.
+3. Select **New repository secret**.
+4. Add each required secret:
+   - `VERCEL_TOKEN`
+   - `VERCEL_ORG_ID`
+   - `VERCEL_PROJECT_ID`
+5. Re-run failed workflows or push a new commit to validate setup.
+
+## How to Obtain Values
+
+- `VERCEL_TOKEN`: Create a personal/team token in Vercel account settings.
+- `VERCEL_ORG_ID` and `VERCEL_PROJECT_ID`: Available from Vercel project settings or via Vercel CLI project linking metadata.
+
+## Typical Failure Modes
+
+### Missing `VERCEL_TOKEN`
+
+- `vercel pull` fails during environment fetch.
+- `vercel build` / `vercel deploy` fails with authentication errors.
+- Preview cleanup script cannot call Vercel API delete endpoints.
+
+### Missing `VERCEL_ORG_ID` or `VERCEL_PROJECT_ID`
+
+- Vercel CLI cannot resolve project context for pull/build/deploy.
+- Cleanup script cannot query correct deployment list for deletion.
+
+## Verification Checklist
+
+- Non-main branch push completes preview deployment workflow.
+- Main branch push/merge completes production deployment workflow.
+- Closing a PR from a preview branch triggers deployment cleanup workflow.
+
+## Maintenance Note
+
+When workflow files change secret usage, update this document and the README CI/CD prerequisites section in the same pull request.


### PR DESCRIPTION
## Summary
- add `CI/CD Prerequisites` section to README
- document required GitHub Actions secrets for Vercel workflows
- add `docs/ci-cd-secrets.md` with setup, workflow mapping, failure modes, and verification steps

## Why
Deployment workflows require Vercel secrets but setup requirements were not clearly documented, making CI/CD setup error-prone for maintainers and forks.

## Validation
- verified README now includes secret list, setup steps, failure symptoms, and quick verification
- verified docs page includes workflow dependency matrix and maintenance note

Fixes #92